### PR TITLE
Revert "Add the Azure Boards badge to the README"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Board Status](https://micardo.visualstudio.com/39917c9c-3518-4cad-b4a6-20d999411c53/f4ec0612-87da-4b03-8d7f-e17189e82039/_apis/work/boardbadge/533f1421-3bbe-49fc-9786-97f2ff312c5a)](https://micardo.visualstudio.com/39917c9c-3518-4cad-b4a6-20d999411c53/_boards/board/t/f4ec0612-87da-4b03-8d7f-e17189e82039/Microsoft.RequirementCategory)
 # carcutter-api-samples
 Code samples for calling the CarCutter API
 


### PR DESCRIPTION
Reverts carcutter/carcutter-api-samples#3

Completes [AB#2356](https://micardo.visualstudio.com/39917c9c-3518-4cad-b4a6-20d999411c53/_workitems/edit/2356)